### PR TITLE
fix: allow renew lease func to work outside of the request context

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Youtube uses pubsubhub to send push notifications for new video uploads. This ap
     "client_id": "", // reddit client id for account that makes posts
     "client_secret": "", // reddit client_secret
     "reddit_password": "", // reddit pw
-    "reddit_username": "" // reddit user
+    "reddit_username": "", // reddit user
+    "URL_ROOT": "https://root_of_your_site/" // for working outside flask request context
 }
 ```

--- a/run.py
+++ b/run.py
@@ -1,3 +1,4 @@
+import os
 from yt_pubsub_handler import create_app
 from yt_pubsub_handler.lease_utils import renew_leases
 
@@ -5,7 +6,8 @@ app = create_app()
 
 
 def run_renew_leases():
-    renew_leases(app)
+    url_root = os.getenv("URL_ROOT")
+    renew_leases(app, url_root=url_root)
 
 
 if __name__ == "__main__":

--- a/yt_pubsub_handler/lease_utils.py
+++ b/yt_pubsub_handler/lease_utils.py
@@ -1,5 +1,6 @@
 import requests
-from flask import Flask, current_app, request
+import os
+from flask import Flask, current_app, request, has_request_context
 from datetime import datetime, timedelta
 from . import models
 
@@ -8,18 +9,19 @@ def renew_leases(app: Flask):
     # check for leases that expire in 24 hours
     # with yt_pubsub_handler.app_context():
     with app.app_context():
+        url_root = os.getenv("URL_ROOT")
         threshold = datetime.utcnow() + timedelta(seconds=60 * 60 * 24)
         current_app.logger.info(f"querying for leases that expire before {threshold}")
         exp_leases = models.Lease.query.filter(models.Lease.lease_expire_ts < threshold)
         if exp_leases.first():
             for lease in exp_leases:
                 current_app.logger.info(f"renewing lease for https://youtube.com/channel/{lease.channel_id}")
-                request_new_lease(lease.channel_id)
+                request_new_lease(lease.channel_id, url_root=url_root)
         else:
             current_app.logger.info(f"no leases to renew, bye!")
 
 
-def request_new_lease(channel_id: str):
+def request_new_lease(channel_id: str, url_root: str = None):
     # helper function to renew a lease with pubsubhub
     headers = {
         "authority": "pubsubhubbub.appspot.com",
@@ -39,8 +41,15 @@ def request_new_lease(channel_id: str):
         "accept-language": "en-US,en;q=0.9",
     }
 
+    if url_root is not None:
+        root = url_root
+    elif has_request_context():
+        root = request.url_root
+    else:
+        raise Exception(f"No request context found, root provided: {url_root}")
+
     data = {
-        "hub.callback": f"{request.url_root}pubsubhub/hook",
+        "hub.callback": f"{root}pubsubhub/hook",
         "hub.topic": f"https://www.youtube.com/xml/feeds/videos.xml?channel_id={channel_id}",
         "hub.verify": "async",
         "hub.mode": "subscribe",

--- a/yt_pubsub_handler/lease_utils.py
+++ b/yt_pubsub_handler/lease_utils.py
@@ -5,11 +5,10 @@ from datetime import datetime, timedelta
 from . import models
 
 
-def renew_leases(app: Flask):
+def renew_leases(app: Flask, url_root: str = None):
     # check for leases that expire in 24 hours
     # with yt_pubsub_handler.app_context():
     with app.app_context():
-        url_root = os.getenv("URL_ROOT")
         threshold = datetime.utcnow() + timedelta(seconds=60 * 60 * 24)
         current_app.logger.info(f"querying for leases that expire before {threshold}")
         exp_leases = models.Lease.query.filter(models.Lease.lease_expire_ts < threshold)


### PR DESCRIPTION
* We cannot access the `request.root_url` outside of a request context.
* I've not found a way to force Flask to provide a request context outside of an actual request
* So there will now be an env variable for the root url of the deployment
    * This is less than ideal, but provides a simple and manageable workaround, preferable to hacking flask itself
    * hopefully we will not change the root url too often :)