### PR TITLE
Db migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Youtube uses pubsubhub to send push notifications for new video uploads. This ap
 1. `zappa deploy production` this will also create the bucket specified in the `s3_bucket` section of `zappa_settings.json`
 2. Ensure that an `env.json` is in the bucket project
     * ex: if `"remote_env": "s3://zappa-yt-pubsub-handler-production/env.json"` then the `env.json` should be place in the appropriate bucket after deploy
-3. Set up db: `zappa invoke dev 'yt_pubsub_handler.db_utils.init_db'`
+3. Set up db: `zappa invoke production 'yt_pubsub_handler.db_utils.init_db'`
 
 # env.json
 ```json
@@ -23,3 +23,16 @@ Youtube uses pubsubhub to send push notifications for new video uploads. This ap
     "URL_ROOT": "https://root_of_your_site/" // for working outside flask request context
 }
 ```
+
+# Migrations
+[Flask-Migrate](https://flask-migrate.readthedocs.io/en/latest/) is used for migrations.
+
+## Running migrations for the production application:
+* Start a local flask session with `./local_dev.sh`
+* Edit `yt_pubsub_handler/models.py` with your intended changes
+* In a seperate terminal, make sure env variable is set: `export FLASK_APP=yt_pubsub_handler` 
+* Run `flask db migrate` to automatically create a revision in the `migrations/versions` folder
+    * **Review this thoroughly** and make any changes, alembic auto-generates these and they may sometimes contain flaws
+* Commit your changes and submit PR. Once merged to master `zappa update production` will push the revision to the prod environment 
+* to execute the migration in production: `zappa invoke production 'run.run_alembic_upgrade'`
+    * for downgrade simply use `run_alembic_downgrade` instead

--- a/migrations/README
+++ b/migrations/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/migrations/alembic.ini
+++ b/migrations/alembic.ini
@@ -1,0 +1,50 @@
+# A generic, single database configuration.
+
+[alembic]
+# template used to generate migration files
+# file_template = %%(rev)s_%%(slug)s
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic,flask_migrate
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[logger_flask_migrate]
+level = INFO
+handlers =
+qualname = flask_migrate
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,91 @@
+from __future__ import with_statement
+
+import logging
+from logging.config import fileConfig
+
+from flask import current_app
+
+from alembic import context
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+fileConfig(config.config_file_name)
+logger = logging.getLogger('alembic.env')
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+config.set_main_option(
+    'sqlalchemy.url',
+    str(current_app.extensions['migrate'].db.get_engine().url).replace(
+        '%', '%%'))
+target_metadata = current_app.extensions['migrate'].db.metadata
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def run_migrations_offline():
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url, target_metadata=target_metadata, literal_binds=True
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+
+    # this callback is used to prevent an auto-migration from being generated
+    # when there are no changes to the schema
+    # reference: http://alembic.zzzcomputing.com/en/latest/cookbook.html
+    def process_revision_directives(context, revision, directives):
+        if getattr(config.cmd_opts, 'autogenerate', False):
+            script = directives[0]
+            if script.upgrade_ops.is_empty():
+                directives[:] = []
+                logger.info('No changes in schema detected.')
+
+    connectable = current_app.extensions['migrate'].db.get_engine()
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            process_revision_directives=process_revision_directives,
+            **current_app.extensions['migrate'].configure_args
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+alembic==1.6.5
 argcomplete==1.12.3
 attrs==20.3.0
 boto3==1.17.84
@@ -8,6 +9,7 @@ chardet==4.0.0
 click==7.1.2
 durationpy==0.5
 Flask==1.1.2
+Flask-Migrate==3.0.1
 flask-ngrok==0.0.25
 Flask-SQLAlchemy==2.5.1
 future==0.18.2
@@ -20,6 +22,7 @@ itsdangerous==1.1.0
 Jinja2==2.11.3
 jmespath==0.10.0
 kappa==0.6.0
+Mako==1.1.4
 MarkupSafe==1.1.1
 mysql-connector-python==8.0.25
 packaging==20.9
@@ -32,10 +35,12 @@ prawcore==2.0.0
 protobuf==3.17.3
 psycopg2-binary==2.8.6
 py==1.10.0
+pycodestyle==2.7.0
 pyparsing==2.4.7
 pytest==6.2.3
 python-dateutil==2.8.1
 python-dotenv==0.16.0
+python-editor==1.0.4
 python-slugify==5.0.2
 pytz==2021.1
 PyYAML==5.4.1

--- a/run.py
+++ b/run.py
@@ -1,6 +1,7 @@
 import os
 from yt_pubsub_handler import create_app
 from yt_pubsub_handler.lease_utils import renew_leases
+from yt_pubsub_handler.db_utils import alembic_downgrade, alembic_migrate, alembic_upgrade
 
 app = create_app()
 
@@ -8,6 +9,18 @@ app = create_app()
 def run_renew_leases():
     url_root = os.getenv("URL_ROOT")
     renew_leases(app, url_root=url_root)
+
+
+def run_alembic_migrate():
+    alembic_migrate(app)
+
+
+def run_alembic_upgrade():
+    alembic_upgrade(app)
+
+
+def run_alembic_downgrade():
+    alembic_downgrade(app)
 
 
 if __name__ == "__main__":

--- a/yt_pubsub_handler/__init__.py
+++ b/yt_pubsub_handler/__init__.py
@@ -1,7 +1,6 @@
 import os
 
 from flask import Flask, render_template
-from flask_sqlalchemy import SQLAlchemy
 from . import models
 
 
@@ -51,4 +50,6 @@ def create_app(test_config=None):
     app.register_blueprint(pubsubhub.bp)
     from . import subscriptions
     app.register_blueprint(subscriptions.bp)
+    from flask_migrate import Migrate
+    migrate = Migrate(app, db)
     return app

--- a/yt_pubsub_handler/db_utils.py
+++ b/yt_pubsub_handler/db_utils.py
@@ -1,5 +1,6 @@
-from flask_sqlalchemy import SQLAlchemy
+from flask import Flask
 from flask.cli import with_appcontext
+from flask_migrate import migrate, upgrade, downgrade
 import click
 from datetime import datetime
 from . import models
@@ -19,3 +20,21 @@ def init_db():
 
 def init_app(app):
     app.cli.add_command(init_db_command)
+
+
+def alembic_migrate(app: Flask):
+    """Creates an automatic revision script"""
+    with app.app_context():
+        migrate()
+
+
+def alembic_upgrade(app: Flask):
+    """Upgrades the database to the latest revision"""
+    with app.app_context():
+        upgrade()
+
+
+def alembic_downgrade(app: Flask):
+    """Downgrades the database to the latest revision"""
+    with app.app_context():
+        downgrade()


### PR DESCRIPTION
Introduces the [Flask-Migrate](https://flask-migrate.readthedocs.io/en/latest/) package, which hooks into the Flask app and uses alembic for database migrations.

Instructions for running migrations for a deployed Flask Zappa app are included in the readme update of this PR. 